### PR TITLE
Add edge-case words

### DIFF
--- a/R/singularize.R
+++ b/R/singularize.R
@@ -77,7 +77,21 @@ singularize <- function(word)
                    feet = "foot",
                    mice = "mouse",
                    people = "person",
-                   lice = "louse")
+                   lice = "louse",
+                   valves = "valve",
+                   trees = "tree",
+                   scribbles = "scribble",
+                   peduncles = "peduncle",
+                   mallees = "mallee",
+                   panicles = "panicle",
+                   ridges = "ridge",
+                   petioles = "petiole",
+                   angles = "angle",
+                   bristles = "bristle",
+                   edges = "edge",
+                   fissures = "fissure",
+                   sutures = "suture",
+                   occurrences = "occurrence")
     
     if(is.null(word))
     {word <- orig.word


### PR DESCRIPTION
These are words that come from botanical descriptions, but I also included some common words that were surprisingly missed by the function, like "trees" and "valves" and "edges".